### PR TITLE
Add nova - a tool to find outdated helm charts

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -57,6 +57,7 @@ Items with :green_heart: indicate open source projects.
 - :green_heart:[Kubetail](https://github.com/johanhaleby/kubetail) :fire::fire::fire::fire: - Bash script that enables you to aggregate (tail/follow) logs from multiple pods into one stream.
 - :green_heart:[stern](https://github.com/wercker/stern) :fire::fire::fire::fire::fire: - Stern allows you to tail multiple pods on Kubernetes and multiple containers within the pod.
 - :green_heart:[kubectl tree](https://github.com/ahmetb/kubectl-tree) :fire::fire::fire::fire: - A kubectl plugin to explore ownership relationships between Kubernetes objects through owners.
+- :green_heart:[nova](https://github.com/FairwindsOps/nova/) - Nova scans your cluster for installed Helm charts, then cross-checks them against all known Helm repositories.
 
 ### Cluster Provisioning
 - :green_heart:[kind](https://github.com/kubernetes-sigs/kind) :fire::fire::fire::fire::fire: - kind is a tool for running local Kubernetes clusters using Docker container "nodes".


### PR DESCRIPTION
I am leaving this open for community to upvote as this repo has less than 50 stars. 

Link to nova: https://github.com/FairwindsOps/nova

## Describe Why This Is Awesome

Why is this awesome?
I have the problem where I don't know if a helm chart needs to updated unless I watch every repository of the services I installed. 
This tool can help me identify when I need to do helm chart updates. 
A cron job can be scheduled to provide this report periodically.

--

Like this pull request?  Vote for it by adding a :+1: