### PR TITLE
Add Kube Karp to the Networking section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -111,7 +111,7 @@ Items with :green_heart: indicate open source projects.
 - :green_heart:[Kong for Kubernetes](https://github.com/Kong/kubernetes-ingress-controller) :fire::fire::fire::fire: - Configure plugins, health checking, load balancing and more in Kong for Kubernetes Services.
 - :green_heart:[ksniff](https://github.com/eldadru/ksniff) :fire::fire::fire: - A kubectl plugin that utilize tcpdump and Wireshark to start a remote capture on any pod in your Kubernetes cluster.
 - :green_heart:[kubectl trace](https://github.com/iovisor/kubectl-trace) :fire::fire::fire: - `kubectl trace` is a kubectl plugin that allows you to schedule the execution of bpftrace programs in your Kubernetes cluster.
-- :green_heart:[Kube Karp](https://github.com/immanuelfodor/kube-karp) - Add a floating virtual IP to Kubernetes cluster nodes for load balancing easily based on the CARP protocol
+- :green_heart:[Kube Karp](https://github.com/immanuelfodor/kube-karp) :fire: - Add a floating virtual IP to Kubernetes cluster nodes for load balancing easily based on the CARP protocol
 - :green_heart:[kubernetes-ingress](https://github.com/nginxinc/kubernetes-ingress) :fire::fire::fire::fire::fire:  - An implementation of an Ingress controller for NGINX and NGINX Plus (commercial).
 - :green_heart:[kube-ovn](https://github.com/alauda/kube-ovn) :fire::fire::fire:  - A Kubernetes Network Fabric for Enterprises that is Rich in Functions and Easy in Operations.
 

--- a/readme.md
+++ b/readme.md
@@ -105,6 +105,7 @@ Items with :green_heart: indicate open source projects.
 - :green_heart:[cert-manager](https://github.com/jetstack/cert-manager) :fire::fire::fire::fire::fire: - cert-manager is a Kubernetes add-on to automate the management and issuance of TLS certificates from various issuing sources.
 - :green_heart:[ksniff](https://github.com/eldadru/ksniff) :fire::fire::fire: - A kubectl plugin that utilize tcpdump and Wireshark to start a remote capture on any pod in your Kubernetes cluster.
 - :green_heart:[kubectl trace](https://github.com/iovisor/kubectl-trace) :fire::fire::fire: - `kubectl trace` is a kubectl plugin that allows you to schedule the execution of bpftrace programs in your Kubernetes cluster.
+- :green_heart:[Kube Karp](https://github.com/immanuelfodor/kube-karp) - Add a floating virtual IP to Kubernetes cluster nodes for load balancing easily based on the CARP protocol
 
 ### Storage
 - :green_heart:[Rook](https://github.com/rook/rook) :fire::fire::fire::fire::fire: - Rook is an open source cloud-native storage orchestrator for Kubernetes.


### PR DESCRIPTION
## Why This Is Awesome? 

[Kube Karp](https://github.com/immanuelfodor/kube-karp)'s unique feature is that it can load balance the Kube API Server without external tools which other LB solutions can not do at the time of writing (e.g., Porter, MetalLB). It does not provide `LoadBalancer` resources for exposed services, it only manages a floating virtual IP accross nodes in the same subnet, so you can always reference the cluster with the same IP address.

--

Like this pull request?  Vote for it by adding a :+1: