### PR TITLE
Add Liqo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -91,6 +91,7 @@ Items with :green_heart: indicate open source projects.
 - :green_heart:[KubeDirector](https://github.com/bluek8s/kubedirector) :fire::fire: - KubeDirector uses standard Kubernetes (K8s) facilities of custom resources and API extensions to implement stateful scaleout application clusters.
 - :green_heart:[The Hierarchical Namespace Controller](https://github.com/kubernetes-sigs/multi-tenancy/tree/master/incubator/hnc) :fire::fire::fire: - Hierarchical namespaces make it easier to share your cluster by making namespaces more powerful.
 - :green_heart:[Kubenav](https://github.com/kubenav/kubenav) :fire::fire::fire: - kubenav is the navigator for your Kubernetes clusters right in your pocket.
+- :green_heart:[Liqo](https://github.com/liqotech/liqo) :fire: - Liqo implements Dynamic resource sharing across different Kubernetes clusters (e.g.; offloading pods and services), supporting decentralized governance.
 
 ### Secrets Management
 - :green_heart:[Kubernetes External Secrets](https://github.com/godaddy/kubernetes-external-secrets) :fire::fire::fire: - Kubernetes External Secrets allows you to use external secret management systems, like AWS Secrets Manager or HashiCorp Vault, to securely add secrets in Kubernetes.


### PR DESCRIPTION
Please add the following projects:
Liqo for "Cluster Resources Management"

## Describe Why This Is Awesome
Liqo is a framework to enable dynamic sharing across Kubernetes Clusters. You can run your pods on a remote cluster seamlessly, without any modification (Kubernetes or your application). More precisely, Liqo is capable to a simple cluster extension, establishing inter-cluster network interconnections and allowing easy pod scaling across cluster. Liqo does not require any modification to the Kubernetes control plane or your application resources.




Like this pull request?  Vote for it by adding a :+1: