### PR TITLE
Add qube - GraphQL API for Kubernetes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -188,6 +188,7 @@ Items with :green_heart: indicate open source projects.
 - :green_heart:[Telepresence](https://github.com/telepresenceio/telepresence) :fire::fire::fire::fire::fire: - Telepresence provides fast, realistic local development for Kubernetes microservices.
 - :green_heart:[Tilt](https://github.com/tilt-dev/tilt) :fire::fire::fire::fire::fire: - Tilt powers multi-service development and makes sure they behave.
 - :green_heart:[Tye](https://github.com/dotnet/tye) :fire::fire::fire::fire: - Tye is a developer tool that makes developing, testing, and deploying microservices and distributed applications easier.
+- :green_heart:[qube](https://github.com/puzl-ee/qube) - qube is a GraphQL API provider for your Kubernetes cluster. GraphQL schema is dynamically built from the openapi/swagger API specification exposed by the Kubernetes cluster.
 
 ### Data Processing and Machine Learning
 - :green_heart:[Kubeflow](https://github.com/kubeflow/kubeflow) :fire::fire::fire::fire::fire: - Kubeflow is a Cloud Native platform for machine learning based on Google’s internal machine learning pipelines.


### PR DESCRIPTION
## Describe Why This Is Awesome

[qube](https://github.com/puzl-ee/qube) is the first known by me GraphQL API for Kubernetes, which supports not only GraphQL queries, but also GraphQL mutations. All GraphQL requests are working with `Bearer` Kubernetes account token.


Like this pull request?  Vote for it by adding a :+1: