### PR TITLE
Adding werf to CI/CD

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -89,6 +89,7 @@ Items with :green_heart: indicate open source projects.
 - :green_heart:[Reloader](https://github.com/stakater/Reloader) :fire::fire::fire::fire: - Reloader can watch changes in `ConfigMap` and `Secret` and do rolling upgrades on Pods with their associated `DeploymentConfigs`, `Deployments`, `Daemonsets` and `Statefulsets`.
 - :green_heart:[Skaffold](https://github.com/GoogleContainerTools/skaffold) :fire::fire::fire::fire::fire: - Skaffold is a command line tool that facilitates continuous development for Kubernetes applications.
 - :green_heart:[Spinnaker](https://github.com/spinnaker/spinnaker) :fire::fire::fire::fire::fire: - Spinnaker is an open-source continuous delivery platform for releasing software changes with high velocity and confidence.
+- :green_heart:[werf](https://github.com/werf/werf) :fire::fire::fire::fire::fire: - werf is a CLI tool glueing Git, Docker, Helm & Kubernetes with any CI system to implement CI/CD and GitOps. 
 
 ### Cluster Resources Management
 - :green_heart:[Grafana Tanka](https://github.com/grafana/tanka) :fire::fire::fire: - The clean, concise and super flexible alternative to YAML for your Kubernetes cluster.
@@ -212,7 +213,7 @@ Items with :green_heart: indicate open source projects.
 - :green_heart:[KubeEdge](https://github.com/kubeedge/kubeedge) :fire::fire::fire::fire::fire: - KubeEdge is built upon Kubernetes and extends native containerized application orchestration and device management to hosts at the Edge.
 - :green_heart:[Kubeless](https://github.com/kubeless/kubeless) :fire::fire::fire::fire::fire: - `kubeless` is a Kubernetes-native serverless framework that lets you deploy small bits of code without having to worry about the underlying infrastructure plumbing.
 - :green_heart:[KubePug](https://github.com/rikatz/kubepug) :fire: - A tool to check deprecations before upgrading Kubernetes version
-- :green_heart:[Shell-operator](https://github.com/flant/shell-operator) :fire::fire::fire: - Shell-operator is a tool for running event-driven scripts in a Kubernetes cluster.
+- :green_heart:[Shell-operator](https://github.com/flant/shell-operator) :fire::fire::fire::fire: - Shell-operator is a tool for running event-driven scripts in a Kubernetes cluster.
 
 ## Guides, Documentations, Blogs, and Learnings
 


### PR DESCRIPTION
## Describe Why This Is Awesome

[werf](https://werf.io/) is a powerful tool to implement GitOps using the existing technologies including Git, Kubernetes, Helm, and any CI system of choice. It improves what they offer (like deploy logging and failures detection for Helm, auto-cleaning Docker images based on Git history, etc.) and "glues" them offering some other features like distributed building and built-in local development support. Currently, it has 2,2k GitHub stars.

_P.S. I've also fixed the number of :fire:'s for our shell-operator since it's over 1k stars already._

Like this pull request?  Vote for it by adding a :+1: