### PR TITLE
Add Plural.sh

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -62,8 +62,8 @@ Items with :green_heart: indicate open source projects.
 - :green_heart:[kubeprompt](https://github.com/jlesquembre/kubeprompt) :fire: - Isolates KUBECONFIG in each shell and shows the current Kubernetes context/namespace in your prompt
 - :green_heart:[Kubevela](https://github.com/oam-dev/kubevela) :fire::fire::fire::fire::fire: - KubeVela is an easy-to-use yet extensible platform that enables them to design and ship applications with minimal effort.
 - :green_heart:[nova](https://github.com/FairwindsOps/nova/) :fire::fire: - Nova scans your cluster for installed Helm charts, then cross-checks them against all known Helm repositories.
-- :green_heart:[stern](https://github.com/wercker/stern) :fire::fire::fire::fire::fire: - Stern allows you to tail multiple pods on Kubernetes and multiple containers within the pod.
 - :green_heart:[Plural](https://github.com/pluralsh/plural) :fire::fire: - Plural is a CLI tool and holistic DevOps management platform for rapidly deploying, managing, and monitoring open-source applications on Kubernetes.
+- :green_heart:[stern](https://github.com/wercker/stern) :fire::fire::fire::fire::fire: - Stern allows you to tail multiple pods on Kubernetes and multiple containers within the pod.
 
 
 ### Cluster Provisioning

--- a/readme.md
+++ b/readme.md
@@ -63,6 +63,8 @@ Items with :green_heart: indicate open source projects.
 - :green_heart:[Kubevela](https://github.com/oam-dev/kubevela) :fire::fire::fire::fire::fire: - KubeVela is an easy-to-use yet extensible platform that enables them to design and ship applications with minimal effort.
 - :green_heart:[nova](https://github.com/FairwindsOps/nova/) :fire::fire: - Nova scans your cluster for installed Helm charts, then cross-checks them against all known Helm repositories.
 - :green_heart:[stern](https://github.com/wercker/stern) :fire::fire::fire::fire::fire: - Stern allows you to tail multiple pods on Kubernetes and multiple containers within the pod.
+- :green_heart:[Plural](https://github.com/pluralsh/plural) :fire::fire: - Plural is a CLI tool and holistic DevOps management platform for rapidly deploying, managing, and monitoring open-source applications on Kubernetes.
+
 
 ### Cluster Provisioning
 - :green_heart:[Bootkube](https://github.com/kubernetes-sigs/bootkube) :fire::fire::fire::fire: - Bootkube is a tool for launching self-hosted Kubernetes clusters.

--- a/readme.md
+++ b/readme.md
@@ -65,7 +65,6 @@ Items with :green_heart: indicate open source projects.
 - :green_heart:[Plural](https://github.com/pluralsh/plural) :fire::fire: - Plural is a CLI tool and holistic DevOps management platform for rapidly deploying, managing, and monitoring open-source applications on Kubernetes.
 - :green_heart:[stern](https://github.com/wercker/stern) :fire::fire::fire::fire::fire: - Stern allows you to tail multiple pods on Kubernetes and multiple containers within the pod.
 
-
 ### Cluster Provisioning
 - :green_heart:[Bootkube](https://github.com/kubernetes-sigs/bootkube) :fire::fire::fire::fire: - Bootkube is a tool for launching self-hosted Kubernetes clusters.
 - :green_heart:[Cluster API](https://github.com/kubernetes-sigs/cluster-api) :fire::fire::fire::fire::fire: - Cluster API is a Kubernetes sub-project focused on providing declarative APIs and tooling to simplify provisioning, upgrading, and operating multiple Kubernetes clusters.


### PR DESCRIPTION
## Why is this awesome?

[Plural](https://github.com/pluralsh/plural) is an open-source Kubernetes DevOps platform that allows users to very easily deploy Kubernetes clusters and open-source stacks on them with their cloud provider of choice. There are currently over 60 open-source applications (and growing) that are deployable onto Plural.

Plural does the following:
- Writes all the Helm, Terraform, and YAML required to deploy your Kubernetes cluster and its applications. If you don't like Plural, you can eject all of the configuration for yourself.
- Handles DNS, registering a fully-qualified domain name for each of your application dashboards and issuing SSL certificates.
- Acts as a OIDC provider, adding a layer of authentication to all of your Kubernetes applications.
- Deploys dependency-aware upgrades to applications.
- Contains tailored runbooks and Grafana dashboards for every application deployable onto the Plural platform.

You can deploy Plural via the CLI or by the virtualized shell provided in the Plural web interface.

Like this pull request?  Vote for it by adding a :+1: