### PR TITLE
Add link to kind_helper and s9k

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -67,7 +67,7 @@ Items with :green_heart: indicate open source projects.
 - :green_heart:[Plural](https://github.com/pluralsh/plural) :fire::fire: - Plural is a CLI tool and holistic DevOps management platform for rapidly deploying, managing, and monitoring open-source applications on Kubernetes.
 - :green_heart:[RBAC Lookup](https://github.com/FairwindsOps/rbac-lookup) :fire::fire::fire: - RBAC Lookup is a CLI that allows you to easily find Kubernetes roles and cluster roles bound to any user, service account, or group name.
 - :green_heart:[stern](https://github.com/stern/stern) :fire::fire::fire::fire::fire: - Stern allows you to tail multiple pods on Kubernetes and multiple containers within the pod.
-- [s9k](https://github.com/MoserMichael/s9k)  - s9k provides a Web UI to to interact with your Kubernetes clusters. You can run the web server locally in a docker container.
+- [s9k](https://github.com/MoserMichael/s9k)  - s9k provides a Web UI to to interact with your Kubernetes clusters. Allows to attach a shell to your pod in your browser. You can run the web server locally in a docker container.
 
 ### Cluster Provisioning
 - :green_heart:[Bootkube](https://github.com/kubernetes-sigs/bootkube) :fire::fire::fire::fire: - Bootkube is a tool for launching self-hosted Kubernetes clusters.

--- a/readme.md
+++ b/readme.md
@@ -67,6 +67,7 @@ Items with :green_heart: indicate open source projects.
 - :green_heart:[Plural](https://github.com/pluralsh/plural) :fire::fire: - Plural is a CLI tool and holistic DevOps management platform for rapidly deploying, managing, and monitoring open-source applications on Kubernetes.
 - :green_heart:[RBAC Lookup](https://github.com/FairwindsOps/rbac-lookup) :fire::fire::fire: - RBAC Lookup is a CLI that allows you to easily find Kubernetes roles and cluster roles bound to any user, service account, or group name.
 - :green_heart:[stern](https://github.com/stern/stern) :fire::fire::fire::fire::fire: - Stern allows you to tail multiple pods on Kubernetes and multiple containers within the pod.
+- [s9k](https://github.com/MoserMichael/s9k)  - s9k provides a Web UI to to interact with your Kubernetes clusters. You can run the web server locally in a docker container.
 
 ### Cluster Provisioning
 - :green_heart:[Bootkube](https://github.com/kubernetes-sigs/bootkube) :fire::fire::fire::fire: - Bootkube is a tool for launching self-hosted Kubernetes clusters.
@@ -83,6 +84,7 @@ Items with :green_heart: indicate open source projects.
 - :green_heart:[microK8s](https://github.com/ubuntu/microk8s) :fire::fire::fire::fire::fire: - The smallest, fastest Kubernetes
 - :green_heart:[Minikube](https://github.com/kubernetes/minikube) :fire::fire::fire::fire::fire: - minikube implements a local Kubernetes cluster on macOS,Linux,all in a binary less than 100 MB.
 - [Kubeadm](https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm/) - kubeadm performs the actions necessary to get a minimum viable cluster up and running.
+- [kind_helper](https://github.com/MoserMichael/kind-helper/) - a script that downloads kind and sets up a kind test cluster, with local docker registry and ingress (as an option)
 
 ### Automation and CI/CD
 - :green_heart:[Argo CD](https://github.com/argoproj/argo-cd) :fire::fire::fire::fire::fire: - Argo CD is a declarative, GitOps continuous delivery tool for Kubernetes.


### PR DESCRIPTION
## Review the Contributing Guidelines

kind_helper has 23 stars 
s9k has 15 stars

## Describe Why This Is Awesome

why this is awesome?

s9k - a web based UI for managing a kubernetes cluster, you can also attach a console to your pod while working inside the web browser. Easy installation via bash script that starts the web server inside a docker container.

kind_helper - automates setting up of kind test cluster with often needed features (local docker registry and ingress). Less hassles with kind, that's awesome!


Like this pull request?  Vote for it by adding a :+1: