### PR TITLE
add Otomi

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -101,6 +101,7 @@ Items with :green_heart: indicate open source projects.
 - :green_heart:[TF-controller](https://github.com/weaveworks/tf-controller) :fire: - TF-controller is an experimental controller for Flux to reconcile Terraform resources in the GitOps way.
 - :green_heart:[werf](https://github.com/werf/werf) :fire::fire::fire::fire::fire: - werf is a CLI tool glueing Git, Docker, Helm & Kubernetes with any CI system to implement CI/CD and GitOps. 
 - :green_heart:[Weave GitOps](https://github.com/weaveworks/weave-gitops) :fire::fire: - Weave GitOps is a simple open source developer platform for people who want cloud native applications, without needing Kubernetes expertise.
+- :green_heart:[Otomi - Self-hosted PaaS for K8s](https://github.com/redkubes/otomi-core) :fire::fire::fire::fire: - Otomi adds developer- and operations-centric tools, automation, and developer self-service on top of Kubernetes in any infrastructure or cloud, to code, build, release, deploy, secure, operate and monitor containerized applications.
 
 ### Cluster Resources Management
 - :green_heart:[Clusterpedia](https://github.com/clusterpedia-io/clusterpedia) :fire: - Clusterpedia is used for complex resource searches across multiple clusters, support simultaneous search of a single kind of resource or multiple kinds of resources existing in multiple clusters.


### PR DESCRIPTION
Why is this awesome?

Otomi adds developer- and operations-centric tools, automation, and developer self-service on top of Kubernetes in any infrastructure or cloud, to code, build, release, deploy, secure, operate and monitor containerized applications.

1 Install, 1 Chart, 1 Schema, to turn any K8s cluster into a complete platform in less than 10 minutes.

Over 20 open source projects, pre-configured, integrated and automated. Try it and be amazed.


Like this pull request?  Vote for it by adding a :+1: