### PR TITLE
add helmfile and helmwave to command tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -47,6 +47,8 @@ Items with :green_heart: indicate open source projects.
 
 ### Command Line Tools
 - :green_heart:[Helm](https://github.com/helm/helm) :fire::fire::fire::fire::fire: - Helm is a tool for managing Charts. Charts are packages of pre-configured Kubernetes resources.
+- :green_heart:[Helmfile](https://github.com/helmfile/helmfile) :fire::fire::fire::fire::fire: - Helmfile is a declarative spec for deploying helm charts.
+- :green_heart:[Helmwave](https://github.com/helmwave/helmwave) :fire::fire::fire: - Helmwave is helm3-native tool for deploy your Helm Charts. It is like Docker-Compose, but for Helm.
 - :green_heart:[Infra](https://github.com/infrahq/infra) :fire::fire::fire: - Infra enables you to discover and access infrastructure (e.g. Kubernetes, databases). We help you connect an identity provider such as Okta or Azure active directory, and map users/groups with the permissions you set to your infrastructure.
 - :green_heart:[K9s](https://github.com/derailed/k9s) :fire::fire::fire::fire::fire: - K9s provides a terminal UI to interact with your Kubernetes clusters.
 - :green_heart:[kapp](https://github.com/vmware-tanzu/carvel-kapp) :fire::fire::fire: - kapp is a simple deployment tool focused on the concept of "Kubernetes application" — a set of resources with the same label


### PR DESCRIPTION
## Describe Why This Is Awesome


Helmfile is a well-known and deserved tool for Helm Chart orchestration.
Helmwave is a newer and more sophisticated tool. It could be compared with Terraform/Terragrunt but for Helm Chart orchestration, as it uses a state file for diff management. I use Helmwave a lot in my production projects.


Like this pull request?  Vote for it by adding a :+1: