### PR TITLE
Add Karpenter

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -86,6 +86,7 @@ Items with :green_heart: indicate open source projects.
 - :green_heart:[microK8s](https://github.com/ubuntu/microk8s) :fire::fire::fire::fire::fire: - The smallest, fastest Kubernetes
 - :green_heart:[Minikube](https://github.com/kubernetes/minikube) :fire::fire::fire::fire::fire: - minikube implements a local Kubernetes cluster on macOS,Linux,all in a binary less than 100 MB.
 - :green_heart:[Talos Linux](https://github.com/siderolabs/talos) :fire::fire::fire::fire::fire: - Talos Linux is a minimal, immutable, secure OS that installs vanilla Kubernetes - for production datacenters, K8s@home, and Edge.
+- :green_heart:[karpenter]([https://karpenter.sh](https://github.com/aws/karpenter-provider-aws)) :fire::fire::fire::fire::fire: - Karpenter is a Kubernetes Node Autoscaler built for flexibility, performance, and simplicity.
 - [Kubeadm](https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm/) - kubeadm performs the actions necessary to get a minimum viable cluster up and running.
 
 ### Automation and CI/CD


### PR DESCRIPTION
Karpenter is a Kubernetes Node Autoscaler built for flexibility, performance, and simplicity.

## Review the Contributing Guidelines

Before submitting a pull request, verify it meets all requirements in the [Contributing Guidelines](https://github.com/tomhuang12/awesome-k8s-resources/blob/master/contributing.md).

## Describe Why This Is Awesome

Why is this awesome?

Karpenter is an open-source node provisioning project built for Kubernetes. Karpenter improves the efficiency and cost of running workloads on Kubernetes clusters by:

* Watching for pods that the Kubernetes scheduler has marked as unschedulable
* Evaluating scheduling constraints (resource requests, nodeselectors, affinities, tolerations, and topology spread constraints) requested by the pods
* Provisioning nodes that meet the requirements of the pods
* Removing the nodes when the nodes are no longer needed

Like this pull request?  Vote for it by adding a :+1: