### PR TITLE
Add AgentTier to Development Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -230,6 +230,7 @@ Items with :green_heart: indicate open source projects.
 
 
 ### Development Tools
+- :green_heart:[AgentTier](https://github.com/agenttier/agenttier) - Kubernetes-native operator that provisions isolated, persistent sandboxes for human developers and AI coding agents through a Sandbox CRD, with built-in governance, optional gVisor isolation, and a streaming agent-mode REST API.
 - :green_heart:[Cyclops](https://github.com/cyclops-ui/cyclops) :fire::fire: - Customizable UI for Kubernetes deployments
 - :green_heart:[Eclipse JKube](https://github.com/eclipse/jkube) :fire::fire: - Tools and plugins for Java developers that help you create container images along with the required manifests to deploy your applications to Kubernetes.
 - :green_heart:[garden](https://github.com/garden-io/garden) :fire::fire::fire::fire::fire: - Garden provides production-like Kubernetes testing environments for integration tests, QA, and development.


### PR DESCRIPTION
This PR adds [AgentTier](https://github.com/agenttier/agenttier) under `### Development Tools`.

AgentTier is an open-source, Kubernetes-native operator that provisions isolated, persistent sandboxes for both human developers and AI coding agents through a single `Sandbox` CRD. Each sandbox is a Pod + PVC + default-deny NetworkPolicy with optional gVisor isolation, hierarchical governance policies, an authenticated browser terminal, and a streaming agent-mode REST API (`POST /configure` + SSE-streaming `POST /invoke`). Distributed as a single Helm chart with a Python SDK, Go CLI, and React Web UI.

License: Apache-2.0. Latest release: v0.3.0 (2026-05-13).

**On the star count:** AgentTier currently has 4 stars (repo created 2026-05-09). I'm submitting under the "community-vouched repo with < 50 stars" provision in CONTRIBUTING.md. Vouching evidence:

- Two awesome-list maintainers have already merged AgentTier into their lists in the last 24 hours: [rootsongjc/awesome-cloud-native#121](https://github.com/rootsongjc/awesome-cloud-native/pull/121) (under Kubernetes Operators) and [jamesmurdza/awesome-ai-devtools#538](https://github.com/jamesmurdza/awesome-ai-devtools/pull/538) (under Agent Infrastructure → Sandboxing & Isolation).
- The project covers a niche this list doesn't yet have: a Kubernetes-native runtime for AI coding agents (Claude Code, LangGraph, OpenHands), with the operator pattern this list is built around.

**Compliance with CONTRIBUTING.md:**

- ✅ Open source (`:green_heart:` tag included), Apache-2.0.
- ✅ Alphabetical placement: `AgentTier` sorts before `Cyclops` so the entry is the new first row.
- ✅ Single-line addition.
- ✅ No fire emojis (project has 4 stars, below the 50-star threshold).

Disclosure: I'm a contributor to AgentTier.
