### PR TITLE
Add Kubebar to Development Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -247,6 +247,7 @@ Items with :green_heart: indicate open source projects.
 - :green_heart:[Tilt](https://github.com/tilt-dev/tilt) :fire::fire::fire::fire::fire: - Tilt powers multi-service development and makes sure they behave.
 - :green_heart:[Tye](https://github.com/dotnet/tye) :fire::fire::fire::fire::fire: - Tye is a developer tool that makes developing, testing, and deploying microservices and distributed applications easier.
 - [Aptakube](https://aptakube.com) - A modern, lightweight and multi-cluster desktop client for Kubernetes. Connect to multiple clusters simultaneously to view, edit and manage all your resources.
+- [Kubebar](https://kubebar.app) - A native macOS & Windows menu-bar/tray client to monitor and manage Kubernetes clusters: pod health at a glance, live logs, one-click restart & scale, Helm, live events, port-forwarding, and an optional bring-your-own-key AI assistant.
 
 ### Data Processing and Machine Learning
 - :green_heart:[Kubeflow](https://github.com/kubeflow/kubeflow) :fire::fire::fire::fire::fire: - Kubeflow is a Cloud Native platform for machine learning based on Google’s internal machine learning pipelines.


### PR DESCRIPTION
Adds Kubebar, a native macOS & Windows menu-bar/tray client for Kubernetes (monitoring + management: health, logs, restart/scale, Helm, events, port-forward, optional BYOK AI assistant). Closed-source/commercial with a free trial - listed below the  open-source items like the existing Aptakube entry, alphabetically. Disclosure: I'm the author. Works with local clusters and AKS/EKS/GKE/DOKS.

It puts full cluster monitoring and management one click away in the macOS menu bar / Windows system tray — no browser tab, no terminal context-switching. It's truly native (no Electron), so it's fast and lightweight, yet covers a lot in one small app: health at a glance, live log streaming, restart & scale, Helm releases, a live event stream, node operations and port-forwarding.
What makes it stand out from the other clients here is the bring-your-own-key AI assistant (Anthropic / OpenAI / Ollama): it explains logs, diagnoses crashing pods, translates kubectl errors and recommends right-sized CPU/RAM limits — with secrets  masked before sending, or fully local via Ollama. Cross-platform, works with local clusters and AKS/EKS/GKE/DOKS, and is localized in 40 languages.