### PR TITLE
add kctx to Testing and Troubleshooting

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -157,6 +157,7 @@ Items with :green_heart: indicate open source projects.
 - :green_heart:[Conftest](https://github.com/open-policy-agent/conftest) :fire::fire::fire::fire: - Conftest helps you write tests against structured configuration data.
 - :green_heart:[DETIK](https://github.com/bats-core/bats-detik) :fire: - A library that simplifies end-to-end testing of K8s applications by using [BATS](https://github.com/bats-core/bats-core) assertions and natural language queries.
 - :green_heart:[k6](https://github.com/loadimpact/k6) :fire::fire::fire::fire::fire: - k6 is a modern load testing tool, building on Load Impact's years of experience in the load and performance testing industry.
+- :green_heart: [kctx]([https://github.com](https://github.com/lucasepe/kctx) - A Kubernetes context engine built for SREs, developers, and AI agents to turn cluster state into a compact, structured model.
 - :green_heart:[ksniff](https://github.com/eldadru/ksniff) :fire::fire::fire::fire: - A kubectl plugin that utilize tcpdump and Wireshark to start a remote capture on any pod in your Kubernetes cluster.
 - :green_heart:[Kube DOOM](https://github.com/storax/kubedoom) :fire::fire::fire::fire: - The next level of chaos engineering is here! Kill pods inside your Kubernetes cluster by shooting them in Doom!
 - :green_heart:[kube-monkey](https://github.com/asobti/kube-monkey) :fire::fire::fire::fire::fire: - It randomly deletes Kubernetes (k8s) pods in the cluster encouraging and validating the development of failure-resilient services.


### PR DESCRIPTION
## Review the Contributing Guidelines

Before submitting a pull request, verify it meets all requirements in the [Contributing Guidelines](https://github.com/tomhuang12/awesome-k8s-resources/blob/master/contributing.md).

## Describe Why This Is Awesome

[`kctx`](https://github.com/lucasepe/kctx) is useful for SREs, platform teams, Kubernetes operators, CI/CD diagnostics, internal tooling, MCP tools, and AI SRE workflows. It turns Kubernetes API state into structured operational context.

Instead of asking every operator, script, dashboard, or agent to reconstruct relationships from raw YAML, [`kctx`](https://github.com/lucasepe/kctx)  exposes a compact model of:

- *entities*: Pods, Services, workloads, Nodes, PVCs, ConfigMaps, Secrets, CRDs
- *relations*: ownership, selection, scheduling, service routing, dependencies
- *signals*: factual observations such as unhealthy Pods, missing endpoints, warning Events, failed readiness, or degraded workloads
- *graphs*: dependency and ownership views around supported resources
- *dumps*: deterministic namespace snapshots for machines and incident review

The tool is intentionally conservative: it reads cluster state, normalizes facts, and avoids speculative root-cause claims.


Like this pull request?  Vote for it by adding a :+1: