### PR TITLE
Add Kubernetes Terminal Simulator

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -317,7 +317,8 @@ Items with :green_heart: indicate open source projects.
 - [Example: Deploying PHP Guestbook application with Redis](https://kubernetes.io/docs/tutorials/stateless-application/guestbook/) - This tutorial shows you how to build and deploy a simple, multi-tier web application using Kubernetes and Docker.
 - [Example: Deploying WordPress and MySQL with Persistent Volumes](https://kubernetes.io/docs/tutorials/stateful-application/mysql-wordpress-persistent-volume/) - This tutorial shows you how to deploy a WordPress site and a MySQL database using Minikube.
 - [Exposing an External IP Address to Access an Application in a Cluster](https://kubernetes.io/docs/tutorials/stateless-application/expose-external-ip-address/) - This guide shows how to create a Kubernetes Service object that exposes an external IP address.
-- [kubectl Cheat Sheet](https://kubernetes.io/docs/reference/kubectl/cheatsheet/) - An official list of commonly used kubectl commands and flags.  
+- [kubectl Cheat Sheet](https://kubernetes.io/docs/reference/kubectl/cheatsheet/) - An official list of commonly used kubectl commands and flags.
+- [Kubernetes Terminal Simulator](https://devops-daily.com/games/kubernetes-terminal-simulator) - Guided kubectl lessons in a simulated terminal in the browser, free and open source with no signup.  
 - [Kubectl Kubernetes CheatSheet](https://github.com/dennyzhang/cheatsheet-kubernetes-A4) :fire::fire::fire::fire: - A cheatsheet containing many helpful kubectl commands
 - [Kubernetes API Reference Docs](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/) - A high-level overview of the basic types of resources provided by the Kubernetes API and their primary functions.  
 - [Learn Kubernetes Basics](https://kubernetes.io/docs/tutorials/kubernetes-basics/) - This tutorial provides a walkthrough of the basics of the Kubernetes cluster orchestration system.


### PR DESCRIPTION
Adds the Kubernetes Terminal Simulator to Learnings and Documentations: guided kubectl lessons in a simulated browser terminal, free with no signup. The project behind it is open source with 1k+ stars: https://github.com/The-DevOps-Daily/devops-daily

Disclosure: I help maintain it.
